### PR TITLE
Adds hotfix to extend support for uk biobank data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,21 @@ name: tests for lifebit-ai/phenowrangle
 on: [push, pull_request]
 
 jobs:
+  plink_ukbio:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        nxf_ver: ['20.01.0', '']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Nextflow
+        run: |
+          export NXF_VER=${{ matrix.nxf_ver }}
+          wget -qO- get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
+      - name: Quantitative plink
+        run: |
+          nextflow run ${GITHUB_WORKSPACE} -profile plink_ukbio
   plink_binary:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,24 @@ jobs:
           export NXF_VER=${{ matrix.nxf_ver }}
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
-      - name: Quantitative plink
+      - name: plink format using ukbio data
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile plink_ukbio
+  plink_ukbio_phewas:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        nxf_ver: ['20.01.0', '']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Nextflow
+        run: |
+          export NXF_VER=${{ matrix.nxf_ver }}
+          wget -qO- get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
+      - name: plink + phewas using ukbio data
+        run: |
+          nextflow run ${GITHUB_WORKSPACE} -profile plink_ukbio_phewas
   plink_binary:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         nxf_ver: ['20.01.0', '']
-        query: ['None', 's3://marcos-lifebit/phenowrangle/query.json']
+        query: ['None', 's3://lifebit-featured-datasets/pipelines/phenowrangle/query.json']
     steps:
       - uses: actions/checkout@v2
       - name: Install Nextflow
@@ -74,7 +74,7 @@ jobs:
         nxf_ver: ['20.01.0', '']
         continuous_var_aggregation: [median]
         continuous_var_transformation: [None]
-        query: ['None', 's3://marcos-lifebit/phenowrangle/query.json']
+        query: ['None', 's3://lifebit-featured-datasets/pipelines/phenowrangle/query.json']
     steps:
       - uses: actions/checkout@v2
       - name: Install Nextflow

--- a/bin/CB_to_plink_pheno.R
+++ b/bin/CB_to_plink_pheno.R
@@ -391,6 +391,8 @@ if (sum(str_detect(colnames(cb_data_transformed), 'icd|hpo|doid')) > 0){
     remove_cols = colnames(cb_data_transformed)[str_detect(colnames(cb_data_transformed), 'icd|hpo|doid')]
     # Generate id_icd_count.csv
     code_df = code_df %>% pivot_longer(!FID, names_to = "vocabulary", values_to = "code") %>% drop_na() %>% select(-vocabulary)
+    # In case the code are in the form "<code> <description>" removes description
+    code_df$code = sapply(strsplit(code_df$code," "), `[`, 1)
     code_df$count = 3 # Do research about this column in particular
     names(code_df)[1]="id"
     write.table(code_df, paste0(out_path,'_id_code_count.csv'), sep=',',  quote=FALSE, row.names=FALSE)

--- a/bin/CB_to_plink_pheno.R
+++ b/bin/CB_to_plink_pheno.R
@@ -116,7 +116,7 @@ id_column = id_column %>% to_snake_case(sep_in = ":|\\(|\\)|(?<!\\d)\\.") %>%
 platekey_col = colnames(cb_data)[str_detect(colnames(cb_data), id_column)]
 if ('i' %in% colnames(cb_data)){
     cb_data['sample_id'] = cb_data[["i"]]
-    if (platekey_col == 'i'){
+    if (id_column == 'i'){
         platekey_col = 'sample_id'
     }
     cb_data = cb_data %>% filter(!cb_data[[platekey_col]] == "") %>% select(-i)

--- a/bin/CB_to_plink_pheno.R
+++ b/bin/CB_to_plink_pheno.R
@@ -115,6 +115,10 @@ id_column = id_column %>% to_snake_case(sep_in = ":|\\(|\\)|(?<!\\d)\\.") %>%
             str_replace_all("-[^-]+$", "")
 platekey_col = colnames(cb_data)[str_detect(colnames(cb_data), id_column)]
 if ('i' %in% colnames(cb_data)){
+    cb_data['sample_id'] = cb_data[["i"]]
+    if (platekey_col == 'i'){
+        platekey_col = 'sample_id'
+    }
     cb_data = cb_data %>% filter(!cb_data[[platekey_col]] == "") %>% select(-i)
 }
 if (-('i' %in% colnames(cb_data))){
@@ -151,7 +155,7 @@ encode_pheno_values = function(column, data, pheno_dictionary, transformation, a
     ################################
     # Individual ID                #
     ################################
-    if (column %in% c("individual_id", 'i', 'eid')){
+    if (column %in% c("individual_id", 'i', 'eid', 'sample_id')){
 
         pheno_cols = data[[column]]
         return(pheno_cols)
@@ -365,7 +369,7 @@ cb_data_transformed$MAT = 0
 # This should be provided either by default from the CB output or as an argument or calculated from the VCF data
 cb_data_transformed$PHE = cb_data_transformed[[column_to_PHE]]
 
-donor_id_col = colnames(cb_data_transformed)[str_detect(colnames(cb_data_transformed), 'individual_id|eid')]
+donor_id_col = colnames(cb_data_transformed)[str_detect(colnames(cb_data_transformed), 'individual_id|eid|sample_id')]
 cb_data_transformed[donor_id_col] = NULL
 
 ##################################################

--- a/bin/CB_to_plink_pheno.R
+++ b/bin/CB_to_plink_pheno.R
@@ -113,12 +113,14 @@ if (query_file == 'None'){
 ##################################################
 id_column = id_column %>% to_snake_case(sep_in = ":|\\(|\\)|(?<!\\d)\\.") %>% 
             str_replace_all("-[^-]+$", "")
+
+## Hotfix for i as id column
+cb_data['sample_id'] = cb_data[["i"]]
+if (id_column == 'i'){
+    platekey_col = 'sample_id'
+}
 platekey_col = colnames(cb_data)[str_detect(colnames(cb_data), id_column)]
 if ('i' %in% colnames(cb_data)){
-    cb_data['sample_id'] = cb_data[["i"]]
-    if (id_column == 'i'){
-        platekey_col = 'sample_id'
-    }
     cb_data = cb_data %>% filter(!cb_data[[platekey_col]] == "") %>% select(-i)
 }
 if (-('i' %in% colnames(cb_data))){

--- a/bin/CB_to_plink_pheno.R
+++ b/bin/CB_to_plink_pheno.R
@@ -119,7 +119,8 @@ cb_data['sample_id'] = cb_data[["i"]]
 if (id_column == 'i'){
     platekey_col = 'sample_id'
 } 
-if {id_column != 'i'){
+
+if (id_column != 'i'){
     platekey_col = colnames(cb_data)[str_detect(colnames(cb_data), id_column)]
 }
 

--- a/bin/CB_to_plink_pheno.R
+++ b/bin/CB_to_plink_pheno.R
@@ -118,8 +118,12 @@ id_column = id_column %>% to_snake_case(sep_in = ":|\\(|\\)|(?<!\\d)\\.") %>%
 cb_data['sample_id'] = cb_data[["i"]]
 if (id_column == 'i'){
     platekey_col = 'sample_id'
+} 
+if {id_column != 'i'){
+    platekey_col = colnames(cb_data)[str_detect(colnames(cb_data), id_column)]
 }
-platekey_col = colnames(cb_data)[str_detect(colnames(cb_data), id_column)]
+
+
 if ('i' %in% colnames(cb_data)){
     cb_data = cb_data %>% filter(!cb_data[[platekey_col]] == "") %>% select(-i)
 }

--- a/bin/CB_to_plink_pheno.R
+++ b/bin/CB_to_plink_pheno.R
@@ -114,8 +114,9 @@ if (query_file == 'None'){
 id_column = id_column %>% to_snake_case(sep_in = ":|\\(|\\)|(?<!\\d)\\.") %>% 
             str_replace_all("-[^-]+$", "")
 
+print(id_column)
+
 ## Hotfix for i as id column
-cb_data['sample_id'] = cb_data[["i"]]
 if (id_column == 'i'){
     platekey_col = 'sample_id'
 } 
@@ -126,12 +127,14 @@ if (id_column != 'i'){
 
 
 if ('i' %in% colnames(cb_data)){
-    cb_data = cb_data %>% filter(!cb_data[[platekey_col]] == "") %>% select(-i)
+    cb_data['sample_id'] = cb_data[["i"]]
+    print(platekey_col)
+    print(cb_data)
+    cb_data = cb_data[!cb_data[[platekey_col]] == "", ] %>% select(-i)
 }
 if (-('i' %in% colnames(cb_data))){
-    cb_data = cb_data %>% filter(!cb_data[[platekey_col]] == "")
+    cb_data = cb_data[!cb_data[[platekey_col]] == "",]
 }
-#Compress multiple measures into a single measurement
 
 
 ##################################################
@@ -376,7 +379,7 @@ cb_data_transformed$MAT = 0
 # This should be provided either by default from the CB output or as an argument or calculated from the VCF data
 cb_data_transformed$PHE = cb_data_transformed[[column_to_PHE]]
 
-donor_id_col = colnames(cb_data_transformed)[str_detect(colnames(cb_data_transformed), 'individual_id|eid|sample_id')]
+donor_id_col = colnames(cb_data_transformed)[str_detect(colnames(cb_data_transformed), 'individual_id|eid')]
 cb_data_transformed[donor_id_col] = NULL
 
 ##################################################
@@ -398,7 +401,7 @@ if (sum(str_detect(colnames(cb_data_transformed), 'icd|hpo|doid')) > 0){
 # Write .phe file                                #
 ##################################################
 
-cb_data_transformed = cb_data_transformed %>% select(FID, IID, PAT, MAT, PHE, everything(), -!!as.symbol(column_to_PHE), -!!as.symbol(id_column), -any_of(id_blacklist))
+cb_data_transformed = cb_data_transformed %>% select(FID, IID, PAT, MAT, PHE, everything(), -!!as.symbol(column_to_PHE), -!!as.symbol(platekey_col), -any_of(id_blacklist))
 ### FID, IID this has to be the platekey metadata -> Agg VCF columns. 
 write.table(cb_data_transformed, paste0(out_path,'.phe'), sep='\t',  quote=FALSE, row.names=FALSE)
 print('done')

--- a/conf/plink_binary.config
+++ b/conf/plink_binary.config
@@ -12,7 +12,7 @@ docker.enabled = true
 
 params  {
     mode='plink'
-    query="s3://marcos-lifebit/phenowrangle/query.json"
+    query="s3://lifebit-featured-datasets/pipelines/phenowrangle/query.json"
     pheno_data = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/cohort_data_phenos.csv"
     pheno_metadata = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/metadata.csv"
     continuous_var_aggregation = "mean"

--- a/conf/plink_phewas.config
+++ b/conf/plink_phewas.config
@@ -12,7 +12,7 @@ docker.enabled = true
 
 params  {
     mode='plink'
-    query="s3://marcos-lifebit/phenowrangle/query.json"
+    query="s3://lifebit-featured-datasets/pipelines/phenowrangle/query.json"
     pheno_data = "s3://lifebit-featured-datasets/projects/gel/phewas/testdata/cohort_data_phenos_phewas.csv"
     pheno_metadata = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/metadata.csv"
     continuous_var_transformation = "None"

--- a/conf/plink_qt.config
+++ b/conf/plink_qt.config
@@ -12,7 +12,7 @@ docker.enabled = true
 
 params  {
     mode='plink'
-    query="s3://marcos-lifebit/phenowrangle/query.json"
+    query="s3://lifebit-featured-datasets/pipelines/phenowrangle/query.json"
     pheno_data = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/cohort_data_phenos.csv"
     pheno_metadata = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/metadata.csv"
     continuous_var_aggregation = "mean"

--- a/conf/plink_ukbio.config
+++ b/conf/plink_ukbio.config
@@ -12,9 +12,9 @@ docker.enabled = true
 
 params  {
     mode='plink'
-    query="s3://marcos-lifebit/phenowrangle/ukbio.json"
-    pheno_data = "s3://marcos-lifebit/phenowrangle/ukbio.csv"
-    pheno_metadata = "s3://marcos-lifebit/phenowrangle/ukbio_meta.csv"
+    query="s3://lifebit-featured-datasets/pipelines/phenowrangle/ukbio.json"
+    pheno_data = "s3://lifebit-featured-datasets/pipelines/phenowrangle/ukbio.csv"
+    pheno_metadata = "s3://lifebit-featured-datasets/pipelines/phenowrangle/ukbio_meta.csv"
     continuous_var_aggregation = "mean"
     continuous_var_transformation = "zscore"
     pheno_col = "Sex"

--- a/conf/plink_ukbio.config
+++ b/conf/plink_ukbio.config
@@ -21,6 +21,7 @@ params  {
     trait_type = "binary"
     case_group = "Male"
     design_mode = "case_vs_control_contrast"
+    id_column = "i"
 
 
     // Limit resources so that this can run on GitHub Actions

--- a/conf/plink_ukbio.config
+++ b/conf/plink_ukbio.config
@@ -1,0 +1,28 @@
+/*
+ * -----------------------------------------------------------------
+ *  lifebit-ai/phenowrangle plink_ukbio config file
+ * -----------------------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ * nextflow run main.nf -profile plink_ukbio
+ */
+
+
+docker.enabled = true
+
+params  {
+    mode='plink'
+    query="s3://marcos-lifebit/phenowrangle/ukbio.json"
+    pheno_data = "s3://marcos-lifebit/phenowrangle/ukbio.csv"
+    pheno_metadata = "s3://marcos-lifebit/phenowrangle/ukbio_meta.csv"
+    continuous_var_aggregation = "mean"
+    continuous_var_transformation = "zscore"
+    pheno_col = "Sex"
+    trait_type = "binary"
+    case_group = "Male"
+    design_mode = "case_vs_control_contrast"
+
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus = 2
+}

--- a/conf/plink_ukbio_phewas.config
+++ b/conf/plink_ukbio_phewas.config
@@ -12,9 +12,9 @@ docker.enabled = true
 
 params  {
     mode='plink'
-    query="s3://marcos-lifebit/phenowrangle/ukbio.json"
-    pheno_data = "s3://marcos-lifebit/phenowrangle/ukbio_phewas.csv"
-    pheno_metadata = "s3://marcos-lifebit/phenowrangle/ukbio_meta_phewas.csv"
+    query="s3://lifebit-featured-datasets/pipelines/phenowrangle/ukbio.json"
+    pheno_data = "s3://lifebit-featured-datasets/pipelines/phenowrangle/ukbio_phewas.csv"
+    pheno_metadata = "s3://lifebit-featured-datasets/pipelines/phenowrangle/ukbio_meta_phewas.csv"
     continuous_var_aggregation = "mean"
     continuous_var_transformation = "zscore"
     pheno_col = "Sex"

--- a/conf/plink_ukbio_phewas.config
+++ b/conf/plink_ukbio_phewas.config
@@ -1,0 +1,30 @@
+/*
+ * -----------------------------------------------------------------
+ *  lifebit-ai/phenowrangle plink_ukbio config file
+ * -----------------------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ * nextflow run main.nf -profile plink_ukbio
+ */
+
+
+docker.enabled = true
+
+params  {
+    mode='plink'
+    query="s3://marcos-lifebit/phenowrangle/ukbio.json"
+    pheno_data = "s3://marcos-lifebit/phenowrangle/ukbio_phewas.csv"
+    pheno_metadata = "s3://marcos-lifebit/phenowrangle/ukbio_meta_phewas.csv"
+    continuous_var_aggregation = "mean"
+    continuous_var_transformation = "zscore"
+    pheno_col = "Sex"
+    trait_type = "binary"
+    case_group = "Male"
+    design_mode = "case_vs_control_contrast"
+    id_column = "i"
+    phewas = true
+
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus = 2
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,7 +25,7 @@ nextflow run main.nf \
   --trait_type "binary" \
 ```
 
-#### plink Quantitative
+#### plink Quantitative
 
 ```bash
 nextflow run main.nf \

--- a/main.nf
+++ b/main.nf
@@ -88,7 +88,7 @@ log.info "-\033[2m--------------------------------------------------\033[0m-"
   Channel preparation
 ---------------------------------------------------*/
 
-ch_query =  params.query ? Channel.value(file(params.query)) : false
+ch_query =  params.query ? Channel.value(file(params.query)) : 'None'
 ch_pheno_data = params.pheno_data ? Channel.value(file(params.pheno_data)) : Channel.empty()
 ch_pheno_metadata = params.pheno_metadata ? Channel.value(file(params.pheno_metadata)) : Channel.empty()
 

--- a/main.nf
+++ b/main.nf
@@ -127,6 +127,7 @@ if (params.mode == 'plink'){
                             --query_file "${query_file}" \
                             --continuous_var_transformation "${params.continuous_var_transformation}" \
                             --continuous_var_aggregation "${params.continuous_var_aggregation}" \
+                            --id_column "${params.id_column}" \
                             --outdir "." \
                             --output_tag "${params.output_tag}"
       """

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,6 +62,7 @@ profiles {
   plink_binary { includeConfig 'conf/plink_binary.config' }
   plink_qt { includeConfig 'conf/plink_qt.config' }
   plink_phewas { includeConfig 'conf/plink_phewas.config' }
+  plink_ukbio { includeConfig 'conf/plink_ukbio.config' }
 }
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,7 +20,7 @@ params {
   pheno_col = false
   pheno_data = false
   pheno_metadata = false
-  query = 'None'
+  query = false
   design_mode = false
   case_group = false
   phewas = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,7 +20,7 @@ params {
   pheno_col = false
   pheno_data = false
   pheno_metadata = false
-  query = false
+  query = 'None'
   design_mode = false
   case_group = false
   phewas = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -63,6 +63,7 @@ profiles {
   plink_qt { includeConfig 'conf/plink_qt.config' }
   plink_phewas { includeConfig 'conf/plink_phewas.config' }
   plink_ukbio { includeConfig 'conf/plink_ukbio.config' }
+  plink_ukbio_phewas { includeConfig 'conf/plink_ukbio_phewas.config'}
 }
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container


### PR DESCRIPTION
# This PR does...

Adds hotfix for running ukbio similar data: 

When the column with the ids is named 'i'. This caused problems because the `str_detect` function doesn't like regex of 1 character. Besides, we used to remove this column, now it's accounted for and it should work fine.

It also adds support to ICD10 codes in UK biobank format: `<code> <description>`.

# Jobs in CloudOS
http://63.35.220.177/app/jobs/60468e15c21f9519de103bb3 -> Gwas data
http://63.35.220.177/app/jobs/6048f77fc21f9519de10ba08 -> Phewas data